### PR TITLE
Add Simulated Annealing's description in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ In this package, four functions are included to lead with feature selection:
 
 * `variance_threshold_select` - Perform simmulated annealing to select features: randomly choose a set of features and determine model performance. Then slightly modify the chosen features randomly and test to see if the modified feature list has improved model performance. If there is improvement, the newer model is kept, if not, a test is performed to determine if the worse model is still kept based on a acceptance probability that decreases as iterations continue and how worse the newer model performs. The process is repeated for a set number of iterations.
 
-* `<simulated annealing>` - TO DESCRIBE
+* `simulated_annealing_select` - Perform simmulated annealing to select features: randomly choose a set of features and determine model performance. Then slightly modify the chosen features randomly and test to see if the modified feature list has improved model performance. If there is improvement, the newer model is kept, if not, a test is performed to determine if the worse model is still kept based on a acceptance probability that decreases as iterations continue and how worse the newer model performs. The process is repeated for a set number of iterations.
 
 ## Installation:
 


### PR DESCRIPTION
Add the the description of the `simulated_annealing_select` function in R package, which I copy-paste from the [README file of our Python package](https://github.com/UBC-MDS/feature-selection-python/blob/4583c82615ed223ae8541be06c7282bc0003cf30/README.md):
*"Perform simmulated annealing to select features: randomly choose a set of features and determine model performance. Then slightly modify the chosen features randomly and test to see if the modified feature list has improved model performance. If there is improvement, the newer model is kept, if not, a test is performed to determine if the worse model is still kept based on a acceptance probability that decreases as iterations continue and how worse the newer model performs. The process is repeated for a set number of iterations."*