### PR TITLE
Other CD improvements

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+      - ubuntu
   pull_request:
     branches:
       - '**'
@@ -20,6 +21,7 @@ jobs:
         config:
           - {os: windows-latest, r: '3.6'}
           - {os: macOS-latest, r: '3.6'}
+          - {os: ubuntu-16.04, r: '3.4', rspm: "https://demo.rstudiopm.com/all/__linux__/xenial/latest"}
 
     env:
       R_REMOTES_NO_ERRORS_FROM_WARNINGS: true

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -22,6 +22,7 @@ jobs:
           - {os: windows-latest, r: '3.6'}
           - {os: macOS-latest, r: '3.6'}
           - {os: ubuntu-16.04, r: '3.4', rspm: "https://demo.rstudiopm.com/all/__linux__/xenial/latest"}
+          - {os: ubuntu-16.04, r: '3.6', rspm: "https://demo.rstudiopm.com/all/__linux__/xenial/latest"}
 
     env:
       R_REMOTES_NO_ERRORS_FROM_WARNINGS: true

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - master
-      - ubuntu
   pull_request:
     branches:
       - '**'

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,10 +1,10 @@
 Package: featureselection
 Title: Feature Selection
 Version: 0.0.0.9000
-Authors@R: c(person("Victor", "Cuspinera", role = c("aut"), email = "TBA"),
+Authors@R: c(person("Victor", "Cuspinera", role = c("aut"), email = "vcuspinera@gmail.com"),
              person("Ryan", "Homer", role = c("aut", "cre"), email = "ryan.homer@alumni.ubc.ca"),
-             person("Jacky", "Ho", role = c("aut"), email = "TBA"),
-             person("Derek", "Kruszewski", role = c("aut"), email = "TBA"))
+             person("Jacky", "Ho", role = c("aut"), email = "jackyho112dev@gmail.com"),
+             person("Derek", "Kruszewski", role = c("aut"), email = "derek.j.kruszewski@gmail.com"))
 Description: Feature Selection with machine learning models.
 License: MIT + file LICENSE
 Encoding: UTF-8

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -19,7 +19,7 @@ Suggests:
 Imports:
     dplyr (>= 0.8.0),
     purrr (>= 0.3.0),
-    stats (>= 3.6.0)
+    stats
 URL: https://github.com/UBC-MDS/feature-selection-r
 BugReports: https://github.com/UBC-MDS/feature-selection-r/issues
 VignetteBuilder: knitr

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: featureselection
 Title: Feature Selection
-Version: 0.0.0.9000
+Version: 1.0.0.0
 Authors@R: c(person("Victor", "Cuspinera", role = c("aut"), email = "vcuspinera@gmail.com"),
              person("Ryan", "Homer", role = c("aut", "cre"), email = "ryan.homer@alumni.ubc.ca"),
              person("Jacky", "Ho", role = c("aut"), email = "jackyho112dev@gmail.com"),


### PR DESCRIPTION
- Adds "ubuntu with R 3.4" and "ubuntu with R 3.6" to the matrix config
- Removes restriction on `stats` version since that's included with R installations, so that ubuntu checks work
- Add everyone's email in `DESCRIPTION`
- Set version number to `1.0.0` (actually `1.0.0.0` with build number)